### PR TITLE
feat: Add functionality to filter and create diverse questions from existing QA pairs

### DIFF
--- a/src/knowornot/QuestionExtractor/__init__.py
+++ b/src/knowornot/QuestionExtractor/__init__.py
@@ -180,6 +180,49 @@ class QuestionExtractor:
 
         return output
 
+    def filter_questions(
+        self,
+        method: FilterMethod,
+        path_to_save: Path,
+        identifier: str,
+        questions: List[QAPair],
+        diversity_threshold_keyword: float = 0.3,
+        diversity_threshold_semantic: float = 0.3,
+    ) -> QuestionDocument:
+        filtered_questions = self._get_diverse_questions(
+            question_list=questions,
+            method=method,
+            diversity_threshold_keyword=diversity_threshold_keyword,
+            diversity_threshold_semantic=diversity_threshold_semantic,
+        )
+
+        final_qa_pairs: List[QAPairFinal] = []
+
+        for idx, qapair in enumerate(filtered_questions):
+            identifier = f"{identifier}_{idx}"
+            final_qa_pairs.append(
+                QAPairFinal(
+                    identifier=identifier,
+                    question=qapair.question,
+                    answer=qapair.answer,
+                )
+            )
+
+        output = QuestionDocument(
+            knowledge_base_identifier=identifier,
+            questions=final_qa_pairs,
+            path_to_store=path_to_save,
+        )
+
+        self.logger.info(
+            f"Generated {len(output.questions)} questions from {len(filtered_questions)} pairs."
+        )
+        self.logger.info(
+            f"{len(filtered_questions) - len(output.questions)} pairs were filtered out because they were too similar"
+        )
+
+        return output
+
     def _preprocess_text(self, text: str) -> str:
         """
         Preprocess text for TF-IDF analysis:


### PR DESCRIPTION

This commit introduces the `create_diverse_questions_from_QAPairs` method to the `KnowOrNot` class. This method allows users to input a list of QA pairs, specify a filtering method (keyword, semantic, or both), and generates a diverse set of questions. It saves the output questions in a designated path.

Key changes:

-   Added `create_diverse_questions_from_QAPairs` method: Takes a list of dictionaries (QA pairs), a filtering method, and other parameters to generate diverse questions.
-   Implemented method to preprocess input: Uses internal `_get_question_manager` to handle the filtering logic.
-   Added error handling: Raises `ValueError` if the input `method` is invalid or if qa_pairs are not dictionaries with 'question' and 'answer' keys.
-   Enhanced code reusability: Leverages existing `QuestionExtractor` filter capabilities for question diversification.
