### PR TITLE
Feat/add xml evaluator

### DIFF
--- a/src/knowornot/Evaluator/__init__.py
+++ b/src/knowornot/Evaluator/__init__.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from ..SyncLLMClient import SyncLLMClient, SyncLLMClientEnum
 import logging
 from ..common.models import (
+    ContextOptionsEnum,
     ExperimentOutputDocument,
     EvaluatedExperimentDocument,
     EvaluationMetadata,
@@ -42,16 +43,19 @@ class Evaluator:
 
         output += f"\nThe model's answer was {response.llm_response.response}"
 
-        if "question" in evaluation_metadata.in_context:
+        if ContextOptionsEnum.QUESTION in evaluation_metadata.in_context:
             output += (
                 f"\nQuestion: {response.experiment_input.source_context_qa.question}"
             )
 
-        if "expected_answer" in evaluation_metadata.in_context:
+        if ContextOptionsEnum.EXPECTED_ANSWER in evaluation_metadata.in_context:
             output += f"\n Actual Answer: {response.experiment_input.source_context_qa.expected_answer}"
 
-        if "context" in evaluation_metadata.in_context:
+        if ContextOptionsEnum.CONTEXT in evaluation_metadata.in_context:
             output += f"\nContext: {response.experiment_input.source_context_qa.context_questions}"
+
+        if ContextOptionsEnum.CITED_QA in evaluation_metadata.in_context:
+            output += f"\nCited QA: {response.cited_QA}"
 
         return output
 

--- a/src/knowornot/Evaluator/__init__.py
+++ b/src/knowornot/Evaluator/__init__.py
@@ -57,6 +57,13 @@ class Evaluator:
         if ContextOptionsEnum.CITED_QA in evaluation_metadata.in_context:
             output += f"\nCited QA: {response.cited_QA}"
 
+        output += f"""Your task is to decide what the value is for the label {evaluation_metadata.tag_name}.
+
+        Think step by step and think out loud. Then in the end classify it according to what you think is the best output for this task.
+
+        Give an XML tag <{evaluation_metadata.tag_name}> </{evaluation_metadata.tag_name}> with ONLY one of the following values: {", ".join(evaluation_metadata.evaluation_outcomes_list)}. This is compulsory and the answer will not parsed otherwise.
+        """
+
         return output
 
     def _create_metadata_list(

--- a/src/knowornot/__init__.py
+++ b/src/knowornot/__init__.py
@@ -937,10 +937,13 @@ class KnowOrNot:
         prompt_content: str,
         evaluation_outcomes: List[str],
         tag_name: str,
-        in_context: List[Literal["question", "expected_answer", "context"]] = [
+        in_context: List[
+            Literal["question", "expected_answer", "context", "cited_qa"]
+        ] = [
             "question",
             "expected_answer",
             "context",
+            "cited_qa",
         ],
         recommended_llm_client_enum: Optional[SyncLLMClientEnum] = None,
         recommended_llm_model: Optional[str] = None,
@@ -975,10 +978,26 @@ class KnowOrNot:
                 "No default LLM client is available and no client is specified"
             )
 
+        context_options_list: List[ContextOptionsEnum] = []
+
+        for item in in_context:
+            if item == "question":
+                context_options_list.append(ContextOptionsEnum.QUESTION)
+            elif item == "expected_answer":
+                context_options_list.append(ContextOptionsEnum.EXPECTED_ANSWER)
+            elif item == "context":
+                context_options_list.append(ContextOptionsEnum.CONTEXT)
+            elif item == "cited_qa":
+                context_options_list.append(ContextOptionsEnum.CITED_QA)
+            else:
+                raise ValueError(
+                    f"Invalid context option: {item} expected one of {['question', 'expected_answer', 'context', 'cited_qa']}"
+                )
+
         return EvaluationSpec(
             name=evaluation_name,
             prompt=Prompt(content=prompt_content, identifier=prompt_identifier),
-            in_context=in_context,
+            in_context=context_options_list,
             tag_name=tag_name,
             evaluation_outcomes=evaluation_outcomes,
             recommended_llm_client_enum=recommended_llm_client_enum,

--- a/src/knowornot/common/models.py
+++ b/src/knowornot/common/models.py
@@ -216,11 +216,7 @@ class EvaluationSpec(BaseModel):
     recommended_llm_client_enum: Optional[SyncLLMClientEnum]
     recommended_llm_model: Optional[str]
     evaluation_outcomes: List[str]
-    in_context: List[Literal["question", "expected_answer", "context"]] = [
-        "question",
-        "expected_answer",
-        "context",
-    ]
+    in_context: List[ContextOptionsEnum] = list(ContextOptionsEnum)
 
 
 class EvaluationOutput(BaseModel):

--- a/src/knowornot/common/models.py
+++ b/src/knowornot/common/models.py
@@ -242,11 +242,7 @@ class EvaluationMetadata(BaseModel):
     evaluation_prompt: Prompt
     tag_name: str
     evaluation_outcomes_list: List[str]
-    in_context: List[Literal["question", "expected_answer", "context"]] = [
-        "question",
-        "expected_answer",
-        "context",
-    ]
+    in_context: List[ContextOptionsEnum] = list(ContextOptionsEnum)
 
 
 class EvaluatedExperimentDocument(BaseModel):


### PR DESCRIPTION
## Changes
- Refactor: make all context options use the enum instead of hard coded strings. Allows for better pattern matching and reduces dev mistakes in the future
- Feat: Add xml prompting to evaluator so the user doesn't have to do it